### PR TITLE
fix(tools/security-guardian): resolves bad object error when its run in the context of main branch

### DIFF
--- a/.github/workflows/security-guardian.yml
+++ b/.github/workflows/security-guardian.yml
@@ -16,18 +16,19 @@ jobs:
         run: |
           echo "Getting changed CloudFormation templates..."
           mkdir -p changed_templates
-
-          git fetch origin main --depth=1
-
+      
           base_sha="${{ github.event.pull_request.base.sha }}"
           head_sha="${{ github.event.pull_request.head.sha }}"
-          if [[ -z "$base_sha" ]]; then base_sha=$(git merge-base origin/main HEAD); fi
-          if [[ -z "$head_sha" ]]; then head_sha=HEAD; fi
-
-          git diff --name-status "$base_sha" "$head_sha" \
+      
+          git fetch origin main --depth=1
+          git fetch origin pull/${{ github.event.pull_request.number }}/head:pr
+      
+          git checkout pr
+      
+          git diff --name-status "$base_sha" pr \
             | grep -E '^(A|M)\s+.*\.template\.json$' \
             | awk '{print $2}' > changed_files.txt || true
-
+      
           while IFS= read -r file; do
             if [ -f "$file" ]; then
               safe_name=$(echo "$file" | sed 's|/|_|g')
@@ -36,12 +37,13 @@ jobs:
               echo "::warning::Changed file not found in workspace: $file"
             fi
           done < changed_files.txt
-
+      
           if [ -s changed_files.txt ]; then
             echo "files_changed=true" >> $GITHUB_OUTPUT
           else
             echo "files_changed=false" >> $GITHUB_OUTPUT
           fi
+        
   
       - name: Install cfn-guard
         if: steps.filter_files.outputs.files_changed == 'true'


### PR DESCRIPTION

### Issue # (if applicable)

Closes #<issue number here>.

### Reason for this change

<!--What is the bug or use case behind this change?-->
Fixes an issue where security-guardian github action runs but is unable to find changed templates. Since it runs in the context of pull_request_target workflow its unable to find the head commit of PR which is in the base branch. This happened after we switched from pull_request to pull_request_target for improved security posture during the run of the github action. 
```
Run echo "Getting changed CloudFormation templates..."
Getting changed CloudFormation templates...
From https://github.com/aws/aws-cdk
 * branch                  main       -> FETCH_HEAD
fatal: bad object 7c12c04a9d7bde97dda3caec8e3fcf7102f2f938
```
### Description of changes

<!--
What code changes did you make? 
Have you made any important design decisions?
What AWS use cases does this change enable? To enable the use cases, which AWS service features are utilized?
-->

### Describe any new or updated permissions being added

<!-- What new or updated IAM permissions are needed to support the changes being introduced ? -->


### Description of how you validated changes

<!--Have you added any unit tests and/or integration tests?-->

### Checklist
- [ ] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
